### PR TITLE
replace Path::Tiny with even tinier replacements

### DIFF
--- a/.README.pod
+++ b/.README.pod
@@ -50,7 +50,7 @@ localized versions of FCR's package global variables.
 
 This library can be installed in the customary way, I<i.e.,> by a CPAN
 installer program such as F<cpan> or F<cpanm> or by satisfying its
-prerequisites (Capture::Tiny and Path::Tiny, for the test suite only) and then
+prerequisites (Capture::Tiny, for the test suite only) and then
 calling:
 
     perl Makefile.PL

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module File::Copy::Recursive::Reduced
 
+    - Path::Tiny has been removed from prereqs and minimal replacements used
+      instead, so as to allow for the possibility that Path::Tiny using this
+      module in the future.
+
 0.006 Fri Apr 20 10:21:48 EDT 2018
     - File::Copy::Recursive 0.41 has been released to CPAN and
       addresses the problem which was the focus of

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -44,18 +44,3 @@ WriteMakefile(
     })),
     ($mm_ver < 6.31 ? () : (LICENSE => 'perl_5')),
 );
-
-
-__END__
-
-        File::Copy      => 0,
-        File::Spec      => 0,
-        Test::Deep      => 0,
-        Test::File      => 0,
-        File::Temp      => 0,
-        Test::Warn      => 0,
-        File::Glob      => 0,
-        Test::Exception => 0,
-        Cwd             => 0,
-        File::Spec      => 0,
-        Path::Tiny      => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ WriteMakefile(
                         'File::Path'    => 0,
                         'File::Spec'    => 0,
                         'File::Temp'    => 0,
-                        'Path::Tiny'    => 0,
                     },
     # Modern EU::MM enables 'make dist' to write good META.json (and META.yml)
     ($mm_ver < 6.46 ? () : (META_MERGE => {

--- a/README
+++ b/README
@@ -47,7 +47,7 @@ README for Perl extension File-Copy-Recursive-Reduced
  Install
   This library can be installed in the customary way, *i.e.,* by a
   CPAN installer program such as cpan or cpanm or by satisfying
-  its prerequisites (Capture::Tiny and Path::Tiny, for the test
+  its prerequisites (Capture::Tiny, for the test
   suite only) and then calling:
 
       perl Makefile.PL

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ localized versions of FCR's package global variables.
 
 This library can be installed in the customary way, _i.e.,_ by a CPAN
 installer program such as `cpan` or `cpanm` or by satisfying its
-prerequisites (Capture::Tiny and Path::Tiny, for the test suite only) and then
+prerequisites (Capture::Tiny, for the test suite only) and then
 calling:
 
     perl Makefile.PL

--- a/t/001-fcopy.t
+++ b/t/001-fcopy.t
@@ -10,13 +10,13 @@ use Capture::Tiny qw(capture_stderr);
 use File::Path qw(mkpath);
 use File::Spec;
 use File::Temp qw(tempdir);
-use Path::Tiny;
 use lib qw( t/lib );
 use MockHomeDir;
 use Helper ( qw|
     create_tfile_and_name_for_new_file_in_same_dir
     create_tfile
     get_fresh_tmp_dir
+    spew slurp
 |);
 
 my ($from, $to, $rv);
@@ -263,16 +263,16 @@ SKIP: {
 
     $rv = fcopy( "$tmpd/orig/data", "$tmpd/fcopy" );
     is(
-        path("$tmpd/orig/data")->slurp,
-        path("$tmpd/fcopy")->slurp,
+        slurp("$tmpd/orig/data"),
+        slurp("$tmpd/fcopy"),
         "fcopy() defaults as expected when target does not exist"
     );
 
-    path("$tmpd/fcopyexisty")->spew("oh hai");
+    spew("$tmpd/fcopyexisty", "oh hai");
     my @fcopy_rv = fcopy( "$tmpd/orig/data", "$tmpd/fcopyexisty");
     is(
-        path("$tmpd/orig/data")->slurp,
-        path("$tmpd/fcopyexisty")->slurp,
+        slurp("$tmpd/orig/data"),
+        slurp("$tmpd/fcopyexisty"),
         "fcopy() defaults as expected when target does exist"
     );
 

--- a/t/003-rcopy.t
+++ b/t/003-rcopy.t
@@ -11,7 +11,6 @@ use File::Find;
 use File::Path qw(mkpath);
 use File::Spec;
 use File::Temp qw(tempdir);
-use Path::Tiny;
 use lib qw( t/lib );
 use MockHomeDir;
 use Helper ( qw|
@@ -24,6 +23,7 @@ use Helper ( qw|
     touch_left_path_and_test
     prepare_left_side_directories
     make_mixed_directory
+    spew slurp
 |);
 
 my ($from, $to, $rv);
@@ -270,16 +270,16 @@ SKIP: {
 
     $rv = rcopy( "$tmpd/orig/data", "$tmpd/rcopy" );
     is(
-        path("$tmpd/orig/data")->slurp,
-        path("$tmpd/rcopy")->slurp,
+        slurp("$tmpd/orig/data"),
+        slurp("$tmpd/rcopy"),
         "rcopy() defaults as expected when target does not exist"
     );
 
-    path("$tmpd/rcopyexisty")->spew("oh hai");
+    spew("$tmpd/rcopyexisty", "oh hai");
     my @rcopy_rv = rcopy( "$tmpd/orig/data", "$tmpd/rcopyexisty");
     is(
-        path("$tmpd/orig/data")->slurp,
-        path("$tmpd/rcopyexisty")->slurp,
+        slurp("$tmpd/orig/data"),
+        slurp("$tmpd/rcopyexisty"),
         "rcopy() defaults as expected when target does exist"
     );
 

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -17,12 +17,12 @@ use Exporter ();
     prepare_left_side_directories
     make_mixed_directory
     make_imperfect_mixed_directory
+    spew slurp
 | );
 use File::Basename ( qw| basename dirname | );
 use File::Path ( qw| mkpath | );
 use File::Spec;
 use File::Temp ( qw| tempdir | );
-use Path::Tiny;
 
 sub create_tfile {
     my $tdir = shift;
@@ -64,9 +64,9 @@ sub get_fresh_tmp_dir {
         my @created = mkpath($dir, { mode => 0711 });
         die "Unable to create directory $dir for testing: $!" unless @created;
 
-        path("$dir/empty")->spew("");
-        path("$dir/data")->spew("oh hai\n$dir");
-        path("$dir/data_tnl")->spew("oh hai\n$dir\n");
+        spew("$dir/empty", "");
+        spew("$dir/data", "oh hai\n$dir");
+        spew("$dir/data_tnl", "oh hai\n$dir\n");
         no warnings 'once';
         if ($File::Copy::Recursive::Reduced::CopyLink) {
             symlink( "data",    "$dir/symlink" );
@@ -254,6 +254,23 @@ sub make_imperfect_mixed_directory {
         symlinks => \@symlinks_created,
     };
     return $rv;
+}
+
+sub spew {
+    my ($file, $contents) = @_;
+    open(my $fh, '>', $file) or die "cannot open $file for writing: $!";
+    binmode $fh, ':unix';
+    print $fh $contents;
+    return 1;
+}
+
+sub slurp {
+    my ($file) = @_;
+    open(my $fh, $file) or die "cannot open $file for reading: $!";
+    binmode $fh, ':unix';
+    my $buf;
+    read $fh, $buf, -s $file; # File::Slurp in a nutshell
+    return $buf;
 }
 
 1;


### PR DESCRIPTION
This allows for the possibility that Path::Tiny could use File::Copy::Recursive::Reduced in the future.