### PR TITLE
Cygwin, Msys2: Handle case where symlink target does not exist

### DIFF
--- a/lib/File/Copy/Recursive/Reduced.pm
+++ b/lib/File/Copy/Recursive/Reduced.pm
@@ -547,6 +547,9 @@ FCR2 follows that found in FCR to a significant extent.
 Thanks also to Tom Hukins for supplying the patch which corrects FCR's
 problems and which has been incorporated into FCR2 as well.
 
+Hakon Hagland spotted problems on Cygwin and MSYS2 and supplied a pull request
+which was further refined and applied.
+
 =head1 AUTHOR
 
     James E Keenan

--- a/t/001-fcopy.t
+++ b/t/001-fcopy.t
@@ -53,7 +53,7 @@ SKIP: {
         "fcopy() returned undef when provided arguments with identical dev and ino");
     SKIP: {
         skip 'identical-dev-ino check not applicable on Windows', 1
-            if ($^O eq 'MSWin32') ;
+            if ($^O =~ /^(?:MSWin32|msys|cygwin)$/) ;
         like($stderr, qr/\Q$old and $new are identical\E/,
             "fcopy(): got expected warning when provided arguments with identical dev and ino");
     }
@@ -88,11 +88,14 @@ SKIP: {
     is(readlink($xsymlink), $xold, "Symlink $xsymlink points to $xold");
     $xnew = File::Spec->catfile($tdir, 'xnew');
     unlink $xold or die "Unable to unlink $xold during testing: $!";
-    $stderr = capture_stderr { $rv = fcopy($xsymlink, $xnew); };
-    ok(defined $rv, "fcopy() returned defined value when copying from symlink");
-    ok($rv, "fcopy() returned true value when copying from symlink");
-    like($stderr, qr/Copying a symlink \($xsymlink\) whose target does not exist/,
-        "fcopy(): Got expected warning when copying from symlink whose target does not exist");
+    SKIP: {
+        skip "$^O does not support creating broken symlinks", 3 if $^O =~ /^(?:cygwin|msys)$/;
+        $stderr = capture_stderr { $rv = fcopy($xsymlink, $xnew); };
+        ok(defined $rv, "fcopy() returned defined value when copying from symlink");
+        ok($rv, "fcopy() returned true value when copying from symlink");
+        like($stderr, qr/Copying a symlink \($xsymlink\) whose target does not exist/,
+            "fcopy(): Got expected warning when copying from symlink whose target does not exist");
+    }
 }
 
 {

--- a/t/002-dircopy.t
+++ b/t/002-dircopy.t
@@ -60,7 +60,7 @@ my ($from, $to, $rv);
             "dircopy() returned undef when provided arguments with identical dev and ino");
         SKIP: {
             skip 'identical-dev-ino check not applicable on Windows', 1
-                if ($^O eq 'MSWin32') ;
+                if $^O =~ /^(?:cygwin|msys|MSWin32)$/;
             like($stderr, qr/\Q$old and $new are identical\E/,
                 "dircopy(): got expected warning when provided arguments with identical dev and ino");
         }
@@ -237,7 +237,10 @@ my @dirnames = ( qw|
 
         note("Copy directory which holds symlinks");
         mixed_block();
-        mixed_imperfect_block();
+        SKIP: {
+            skip "$^O does not support creating broken symlinks", 7 if $^O =~ /^(?:cygwin|msys)$/;
+            mixed_imperfect_block();
+        }
     }
 }
 


### PR DESCRIPTION
Incorporates https://github.com/jkeenan/file-copy-recursive-reduced/pull/4, in response to https://github.com/jkeenan/file-copy-recursive-reduced/issues/3